### PR TITLE
Bootstrap added for TravisCI in order to prepare for Mac OS X support of

### DIFF
--- a/.bootstrap/puppet/manifests/init.pp
+++ b/.bootstrap/puppet/manifests/init.pp
@@ -1,0 +1,129 @@
+$PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games'
+$VAGRANT_HOME='/home/vagrant'
+$PROJECT_HOME='/vagrant'
+$VIRTUALENV="$VAGRANT_HOME/.syslog-ng-virtualenv"
+
+file { 'locale':
+  ensure  => present,
+  path    => '/etc/environment',
+  content => "LANGUAGE=en_US.UTF-8\nLC_ALL=en_US.UTF-8\nPATH=$PATH",
+  owner   => root,
+  group   => root,
+  mode    => '644',
+}
+
+file { 'hostname':
+  ensure  => present,
+  path    => '/etc/hostname',
+  content => 'syslog-ng.devenv',
+  owner   => root,
+  group   => root,
+  mode    => '644',
+}
+
+exec { 'apt-get-update':
+    command     => '/usr/bin/apt-get update',
+    refreshonly => true,
+}
+
+package { 'curl':
+    ensure => latest,
+    require => Exec['apt-get-update'],
+}
+
+exec { "debian-add-release":
+    command => "curl --silent http://packages.madhouse-project.org/debian/add-release.sh | sh",
+    path    => "$PATH",
+    require => Package['curl'],
+}
+
+$packages = [
+  'pkg-config',
+  'flex',
+  'bison',
+  'xsltproc',
+  'docbook-xsl',
+  'libevtlog-dev',
+  'libnet1-dev',
+  'libglib2.0-dev',
+  'libdbi0-dev',
+  'libssl-dev',
+  'libjson0-dev',
+  'libwrap0-dev',
+  'libpcre3-dev',
+  'libcap-dev',
+  'libesmtp-dev',
+  'libgeoip-dev',
+  'libhiredis-dev',
+  'sqlite3',
+  'libdbd-sqlite3',
+  'libriemann-client-dev',
+  'git',
+  'glib2.0',
+  'vim',
+  'autoconf',
+  'automake',
+  'libtool',
+  'gettext',
+  'zsh',
+]
+
+package { $packages:
+    ensure => latest,
+    require    => [ Exec['apt-get-update'], Exec['debian-add-release'] ],
+}
+
+file { "$VAGRANT_HOME/project":
+   ensure => 'link',
+   target =>  "$PROJECT_HOME",
+}
+
+$shell_profile_files = [
+  "$VAGRANT_HOME/.bash_profile",
+  "$VAGRANT_HOME/.zprofile"
+]
+
+file { $shell_profile_files :
+  ensure  => present,
+  owner   => 'vagrant',
+  group   => 'users',
+  mode    => '0664',
+  content => 'source .syslog-ng-virtualenv/bin/activate',
+}
+
+exec { "autogen":
+  command => "bash autogen.sh",
+  path    => "$PATH",
+  cwd     => "$PROJECT_HOME",
+  user    => 'vagrant',
+  group   => 'users',
+  require => Package[$packages],
+}
+
+exec { "configure":
+  command => "sh configure --with-ivykis=internal --prefix=/home/vagrant/install --enable-pacct --enable-debug",
+  path    => "$PATH",
+  cwd     => "$PROJECT_HOME",
+  user    => 'vagrant',
+  group   => 'users',
+  require =>  Exec['autogen'],
+}
+
+exec { "make":
+  command => "make",
+  path    => "$PATH",
+  cwd     => "$PROJECT_HOME",
+  user    => 'vagrant',
+  group   => 'users',
+  require =>  Exec['configure'],
+}
+
+exec { "install":
+  command => "make install",
+  path    => "$PATH",
+  cwd     => "$PROJECT_HOME",
+  user    => 'vagrant',
+  group   => 'users',
+  require =>  Exec['make'],
+}
+

--- a/.bootstrap/scripts/vagrant_install_ubuntu.sh
+++ b/.bootstrap/scripts/vagrant_install_ubuntu.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+local_setup()
+{
+  echo "LANGUAGE=en_US.UTF-8" > /etc/environment
+  echo "LC_ALL=en_US.UTF-8" >> /etc/environment
+}
+
+host_setup()
+{
+  echo "syslog-ng.devenv" > /etc/hostname
+}
+
+ubuntu_update()
+{
+  sudo apt-get update -qq -y
+  sudo apt-get install -qq -y curl
+  sudo curl --silent http://packages.madhouse-project.org/debian/add-release.sh | sudo sh
+  sudo apt-get update -qq -y
+}
+
+ubuntu_install()
+{
+  sudo apt-get install -qq -y pkg-config flex bison xsltproc docbook-xsl libevtlog-dev libnet1-dev libglib2.0-dev libdbi0-dev libssl-dev libjson0-dev libwrap0-dev libpcre3-dev libcap-dev libesmtp-dev libgeoip-dev libhiredis-dev sqlite3 libdbd-sqlite3 libriemann-client-dev
+  sudo apt-get install -qq -y git vim autoconf automake libtool zsh
+}
+
+devenv_setup()
+{
+  cd /vagrant
+  ./autogen.sh
+  ./configure --with-ivykis=internal           \
+              --prefix=/home/vagrant/install/  \
+              --enable-pacct 
+  make
+  make install
+  cd /home/vagrant
+  sudo ln -s /vagrant /home/vagrant/project
+}
+
+# Bootstrap
+local_setup
+host_setup
+ubuntu_update
+ubuntu_install
+devenv_setup

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,72 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "ubuntu/trusty64"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "puppet" do |puppet|
+      puppet.module_path = "./.bootstrap/puppet/modules"
+      puppet.manifests_path = "./.bootstrap/puppet/manifests"
+      puppet.manifest_file = "init.pp"
+  end
+end


### PR DESCRIPTION
syslog-ng separating install scripts on different OSs.
.travis.yml modified to use this script to install the environment and
dependencies when `linux` envvar is stated. Later `osx` variable will
show that the CI is running on OS X platform.
Another reason for splitting these scripts my willing to create
Vagrantfile for syslog-ng in order to provide "plug 'n' play" devenv for
the ones who want to contribute into the project. (Ubuntu, CentOS,
openSUSE, FreeBSD, etc...) This can be useful for GSoC candidants and
other contributors, too.

Signed-off-by: Gergő Nagy <gergo.nagy@balabit.com>